### PR TITLE
Refer to the correct function from ks package

### DIFF
--- a/R/kde.R
+++ b/R/kde.R
@@ -95,7 +95,7 @@ get_dens <- function(data, dens, method) {
 #' the first two dimensions will be used
 #' @param method Kernel density estimation method:
 #' \itemize{
-#' \item \code{ks}: Computes density using the \code{kda} function from the
+#' \item \code{ks}: Computes density using the \code{kde} function from the
 #'  \code{ks} package.
 #' \item \code{wkde}: Computes density using a modified version of the
 #'  \code{kde2d} function from the \code{MASS}

--- a/R/methods.R
+++ b/R/methods.R
@@ -12,7 +12,7 @@
 #'  default, the first two dimensions are considered.
 #' @param method Kernel density estimation method:
 #' \itemize{
-#' \item \code{ks}: Computes density using the \code{kda} function from the
+#' \item \code{ks}: Computes density using the \code{kde} function from the
 #'  \code{ks} package.
 #' \item \code{wkde}: Computes density using a modified version of the
 #' \code{kde2d} function from the \code{MASS}


### PR DESCRIPTION
As far as I can see `ks::kde` is used for the KDE estimation, not `ks:kda`.