### PR TITLE
Update plotting.R

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -29,7 +29,7 @@ plot_density_ <- function(z, feature, cell_embeddings, dim_names, shape, size,
         xlab(gsub("_", " ", dim_names[1])) +
         ylab(gsub("_", " ", dim_names[2])) +
         ggtitle(feature) +
-        labs(color = guide_legend(legend_title)) +
+        labs(color = legend_title) +
         theme(
             text = element_text(size = 14),
             panel.background = element_blank(),


### PR DESCRIPTION
Made change as described in https://github.com/powellgenomicslab/Nebulosa/issues/22#issuecomment-1966415400, changed `plotting.R` as @pedriniedoardo suggested (`labs(color = guide_legend(legend_title)) +` to `labs(color = legend_title) +` on line 32), and `plot_density()` is now working as expected for me.

```
# Installing my fork of Nebulosa to test `plot_density`
library("devtools")
install_github("beigelk/Nebulosa")

library(Nebulosa)

pbmc = readRDS("~/test_data/pbmc_processed.Rds")
plot_density(pbmc, features = c("LYZ", "CD14"), joint = TRUE)
```
![image](https://github.com/powellgenomicslab/Nebulosa/assets/123108611/acada862-6143-4d50-a59c-25c062ee8776)

