### PR TITLE
add missing imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     Matrix,
     stats, 
     methods,
-    ggrastr
+    ggrastr,
+    SeuratObject
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Suggests: 


### PR DESCRIPTION
@joseah `SeuratObject` is listed in NAMESPACE, but is missing in DESCRIPTION.

This goes as far as failed installation of `SeuratWrappers`, which has `Nebulosa` as a remote dependencies, which should misses `SeuratObject`. This became especially clear when using NixPkgs for reproducible environments. 

https://github.com/ropensci/rix/issues/390#issuecomment-2607175281