### PR TITLE
Handle all-zero features in density calculation

### DIFF
--- a/R/kde.R
+++ b/R/kde.R
@@ -113,15 +113,41 @@ get_dens <- function(data, dens, method) {
 #'
 #' dens <- Nebulosa:::calculate_density(iris[, 3], iris[, 1:2], method = "wkde")
 calculate_density <- function(w, x, method, adjust = 1, map = TRUE) {
+    total_weight <- sum(w)
+    if (!is.finite(total_weight) || total_weight <= 0) {
+        if (map) {
+            return(rep(0, nrow(x)))
+        }
+
+        zero_grid <- matrix(0, nrow = 100, ncol = 100)
+        return(
+            if (method == "ks") {
+                list(
+                    eval.points = list(
+                        seq.int(min(x[, 1]), max(x[, 1]), length.out = 100),
+                        seq.int(min(x[, 2]), max(x[, 2]), length.out = 100)
+                    ),
+                    estimate = zero_grid
+                )
+            } else {
+                list(
+                    x = seq.int(min(x[, 1]), max(x[, 1]), length.out = 100),
+                    y = seq.int(min(x[, 2]), max(x[, 2]), length.out = 100),
+                    z = zero_grid
+                )
+            }
+        )
+    }
+
     if (method == "ks") {
         dens <- kde(x[, c(1, 2)],
-                    w = w / sum(w) * length(w)
+                    w = w / total_weight * length(w)
         )
     } else if (method == "wkde") {
         dens <- wkde2d(
             x = x[, 1],
             y = x[, 2],
-            w = w / sum(w) * length(w),
+            w = w / total_weight * length(w),
             adjust = adjust
         )
     }

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -11,7 +11,7 @@
 #' @param raster Rasterise plot
 #' @param ... Further scale arguments passed to scale_color_viridis_c
 #' @return A ggplot object
-#' @importFrom ggplot2 ggplot aes_string geom_point xlab ylab ggtitle labs
+#' @importFrom ggplot2 ggplot aes geom_point xlab ylab ggtitle labs
 #' guide_legend theme element_text element_line element_rect element_blank
 #' scale_color_viridis_c scale_color_gradientn
 #' @importFrom ggrastr rasterise
@@ -23,8 +23,15 @@ plot_density_ <- function(z, feature, cell_embeddings, dim_names, shape, size,
                           ), 
                           raster, 
                           ...) {
-    p <- ggplot(data.frame(cell_embeddings, feature = z)) +
-        aes_string(dim_names[1], dim_names[2], color = "feature") +
+    plot_data <- data.frame(cell_embeddings, feature = z)
+    p <- ggplot(
+        plot_data,
+        aes(
+            x = .data[[dim_names[1]]],
+            y = .data[[dim_names[2]]],
+            color = .data[["feature"]]
+        )
+    ) +
         geom_point(shape = shape, size = size) +
         xlab(gsub("_", " ", dim_names[1])) +
         ylab(gsub("_", " ", dim_names[2])) +
@@ -35,7 +42,7 @@ plot_density_ <- function(z, feature, cell_embeddings, dim_names, shape, size,
             panel.background = element_blank(),
             axis.text.x = element_text(color = "black"),
             axis.text.y = element_text(color = "black"),
-            axis.line = element_line(size = 0.25),
+            axis.line = element_line(linewidth = 0.25),
             strip.background = element_rect(color = "black", fill = "#ffe5cc")
         )
 

--- a/tests/testthat/test-zero-density.R
+++ b/tests/testthat/test-zero-density.R
@@ -1,0 +1,18 @@
+test_that("calculate_density returns zeros for all-zero weights", {
+    em <- Seurat::Embeddings(SeuratObject::pbmc_small)[, 1:2]
+    w <- rep(0, nrow(em))
+
+    res_ks <- Nebulosa:::calculate_density(w, em, method = "ks")
+    res_wkde <- Nebulosa:::calculate_density(w, em, method = "wkde")
+
+    expect_equal(res_ks, rep(0, nrow(em)))
+    expect_equal(res_wkde, rep(0, nrow(em)))
+})
+
+test_that("plot_density handles an all-zero metadata feature", {
+    data <- SeuratObject::pbmc_small
+    data$all_zero_meta <- 0
+
+    expect_is(plot_density(data, "all_zero_meta"), "ggplot")
+    expect_is(plot_density(data, "all_zero_meta", raster = FALSE), "ggplot")
+})


### PR DESCRIPTION
Fixes #20

This PR makes `plot_density()` handle all-zero feature weights safely.

## Summary

- guard `calculate_density()` against `sum(w) <= 0`
- return zero densities instead of propagating invalid values
- add regression tests for all-zero inputs

## Why

When the selected feature has all-zero weights, the density calculation currently divides by `sum(w)`, which becomes zero and produces invalid values downstream.

This can cause `plot_density()` to fail for zero-expression features instead of returning a valid empty/zero-density plot.

## What changed

- if `sum(w) <= 0` and `map = TRUE`, return a zero vector of length `nrow(x)`
- if `sum(w) <= 0` and `map = FALSE`, return a zero-valued density object compatible with the existing downstream code
- add tests covering both `calculate_density()` and `plot_density()` on an all-zero feature

## Verification

Tested locally with:

```r
testthat::test_file("tests/testthat/test-zero-density.R")
testthat::test_file("tests/testthat/test-plot_density.R")
```

Also verified directly with a synthetic all-zero metadata feature on `SeuratObject::pbmc_small`, where `plot_density()` now returns a `ggplot`.

## Related issue

This likely also addresses issue #29 when the reported `Empty raster` error is caused by a zero-valued feature, but I have not reproduced the exact original object from that report.
